### PR TITLE
resolved improper filepath concatenation in kilosort processing methods.

### DIFF
--- a/+sqKilosort/computeAllMeasures.m
+++ b/+sqKilosort/computeAllMeasures.m
@@ -2,13 +2,17 @@
 
 function [cgs, uQ, cR, isiV] = computeAllMeasures(resultsDirectory)
 
-if exist(fullfile(resultsDirectory, 'cluster_groups.csv'))
-    [cids, cgs] = readClusterGroupsCSV(fullfile(resultsDirectory, 'cluster_groups.csv'));
-elseif exist(fullfile(resultsDirectory, 'spike_clusters.npy'))
-    clu = readNPY(fullfile(resultsDirectory, 'spike_clusters.npy'));
+clusterPath = fullfile(resultsDirectory, 'cluster_groups.csv');
+spikeClustersPath = fullfile(resultsDirectory,'spike_clusters.npy');
+spikeTemplatesPath = fullfile(resultsDirectory,'spike_templates.npy');
+
+if exist(clusterPath, 'file')
+    [cids, cgs] = readClusterGroupsCSV(clusterPath);
+elseif exist(spikeClustersPath, 'file')
+    clu = readNPY(spikeClustersPath);
     cgs = 3*ones(size(unique(clu))); % all unsorted
 else
-    clu = readNPY(fullfile(resultsDirectory, 'spike_templates.npy'));
+    clu = readNPY(spikeTemplatesPath);
     cgs = 3*ones(size(unique(clu))); % all unsorted
 end
 

--- a/+sqKilosort/isiViolations.m
+++ b/+sqKilosort/isiViolations.m
@@ -2,19 +2,27 @@
 
 function isiV = isiViolations(resultsDirectory)
 
+%% Precompute the locationsn of files to be loaded
+spikeClustersPath = fullfile(resultsDirectory,'spike_clusters.npy');
+spikeTemplatesPath = fullfile(resultsDirectory,'spike_templates.npy');
+spikeTimesPath= fullfile(resultsDirectory,'spike_times.npy');
+paramsPath= fullfile(resultsDirectory,'params.py');
+
+%% 
+
 refDur = 0.002;
 minISI = 0.0005;
 
 fprintf(1, 'loading data for ISI computation\n');
-if exist([resultsDirectory 'spike_clusters.npy'])
-    spike_clusters = readNPY([resultsDirectory 'spike_clusters.npy']);
+if exist(spikeClustersPath)
+    spike_clusters = readNPY(spikeClustersPath);
 else
-    spike_clusters = readNPY([resultsDirectory 'spike_templates.npy']);
+    spike_clusters = readNPY(spikeTemplatesPath);
 end
 spike_clusters = spike_clusters + 1; % because in Python indexes start at 0
 
-spike_times = readNPY([resultsDirectory 'spike_times.npy']);
-params = readKSparams([resultsDirectory 'params.py']);
+spike_times = readNPY(spikeTimesPath);
+params = readKSparams(paramsPath);
 spike_times = double(spike_times)/params.sample_rate;
 
 fprintf(1, 'computing ISI violations\n');

--- a/+sqKilosort/maskedClusterQuality.m
+++ b/+sqKilosort/maskedClusterQuality.m
@@ -2,28 +2,35 @@
 function [clusterIDs, unitQuality, contaminationRate] = maskedClusterQualityKilosort(resultsDirectory)
 
 fprintf(1, 'loading data...\n');
+%% Precompute the locationsn of files to be loaded
+pcFeaturesPath = fullfile(resultsDirectory,'pc_features.npy');
+pcFeaturesIndPath = fullfile(resultsDirectory,'pc_feature_ind.npy');
+spikeClustersPath = fullfile(resultsDirectory,'spike_clusters.npy');
+spikeTemplatesPath = fullfile(resultsDirectory,'spike_templates.npy');
 
+
+%% Main code.
 try
-    pc_features = readNPY([resultsDirectory 'pc_features.npy']); % features of each spike
+    pc_features = readNPY(pcFeaturesPath); % features of each spike
 catch me
-    if ~exist([resultsDirectory 'pc_features.npy'])
+    if ~exist(pcFeaturesPath, 'file')
         fprintf(1, 'PC Features loading failed. File does not exist.\n');
     else
         fprintf(1, 'PC Features loading failed. You may need to clone the npy-matlab repo and add to path.\n');
     end
     rethrow me
 end
-pc_feature_ind = readNPY([resultsDirectory 'pc_feature_ind.npy']); % the (small) subset of channels corresponding to each template
+pc_feature_ind = readNPY(pcFeaturesIndPath); % the (small) subset of channels corresponding to each template
 pc_feature_ind = pc_feature_ind + 1;   % because in Python indexes start at 0
 
-if exist([resultsDirectory 'spike_clusters.npy'])
+if exist(spikeClustersPath,'file')
     fprintf('building features matrix from clusters/templates\n')
-    spike_clusters = readNPY([resultsDirectory 'spike_clusters.npy']);
+    spike_clusters = readNPY(spikeClustersPath);
     spike_clusters = spike_clusters + 1; % because in Python indexes start at 0
         
     % now we have to construct a new pc_features that has the features
     % arranged according to *cluster* rather than template. 
-    spike_templates = readNPY([resultsDirectory 'spike_templates.npy']);
+    spike_templates = readNPY(spikeTemplatesPath);
     spike_templates = spike_templates+1;
     
     clusterIDs = unique(spike_clusters);
@@ -76,7 +83,7 @@ if exist([resultsDirectory 'spike_clusters.npy'])
     pc_feature_ind = newFetInds;
 else
     fprintf(1, 'warning, spike_clusters does not exist, using spike_templates instead\n');
-    spike_clusters = readNPY([resultsDirectory 'spike_templates.npy']); % template # corresponding to each spike
+    spike_clusters = readNPY(spikeTemplatesPath); % template # corresponding to each spike
     spike_clusters = spike_clusters + 1; % because in Python indexes start at 0
 end
 


### PR DESCRIPTION
I replaced all instances of the pattern `fileLocation = [rootPath 'file_name.extension']`, which does not insert `filesep()` between items, with calls to `fullfile()`, which does.

In the cases where the same path is used multiple times (e.g., in an existence test and also as a load), I've made that location a variable that's called multiple times, which avoids typo and cut-and-paste errors.

I did not change anything in the `+sqKwik` directory because I don't have anything to test against -- however, please note that the value of `filesep()` is OS-dependent, and matlab will not always resolve paths correctly if the file separator is hard-coded. 
