### PR TITLE
changed text justification on output so that all columns are aligned correctly

### DIFF
--- a/+sqKilosort/isiViolations.m
+++ b/+sqKilosort/isiViolations.m
@@ -34,6 +34,6 @@ for c = 1:numel(clusterIDs)
     [fpRate, numViolations] = ISIViolations(spike_times(spike_clusters==clusterIDs(c)), minISI, refDur);
     isiV(c) = fpRate;
     nSpikes = sum(spike_clusters==clusterIDs(c));    
-    fprintf(1, 'cluster %d: %d viol (%d spikes), %.2f estimated FP rate\n', clusterIDs(c), numViolations, nSpikes, fpRate);
+    fprintf(1, 'cluster %3d: %d viol (%d spikes), %.2f estimated FP rate\n', clusterIDs(c), numViolations, nSpikes, fpRate);
     
 end

--- a/core/maskedClusterQualitySparse.m
+++ b/core/maskedClusterQualitySparse.m
@@ -21,7 +21,7 @@ clusterIDs = unique(clu);
 unitQuality = zeros(size(clusterIDs));
 contaminationRate = zeros(size(clusterIDs));
 
-
+fprintf('%12s\tQuality\tContamination\n', 'ID'); % comment to suppress printing out the intermediate results
 for c = 1:numel(clusterIDs)
     
     theseSp = clu==clusterIDs(c);
@@ -95,7 +95,7 @@ for c = 1:numel(clusterIDs)
     unitQuality(c) = uQ;
     contaminationRate(c) = cR;
     
-    fprintf('cluster %d: \t%2.1f\t%1.2f\n', clusterIDs(c), unitQuality(c), contaminationRate(c)); % comment to suppress printing out the intermediate results
+    fprintf('cluster %3d: \t%6.1f\t%6.2f\n', clusterIDs(c), unitQuality(c), contaminationRate(c)); % comment to suppress printing out the intermediate results
     
     if uQ>1000
         keyboard;


### PR DESCRIPTION
and added explanatory column headers to the output of `ClusterQualitySparse.m`.  A small change :smile_cat: 

output now looks like

```
computing cluster qualities...
          ID    Quality Contamination
cluster   4:      14.8    0.35
cluster  17:      18.4    0.30
cluster 103:      10.6    0.53
```
